### PR TITLE
Integrating "ambient-package-update"

### DIFF
--- a/.ambient-package-update/metadata.py
+++ b/.ambient-package-update/metadata.py
@@ -1,0 +1,44 @@
+from ambient_package_update.metadata.author import PackageAuthor
+from ambient_package_update.metadata.constants import (
+    DEV_DEPENDENCIES,
+    LICENSE_MIT,
+    SUPPORTED_DJANGO_VERSIONS,
+    SUPPORTED_PYTHON_VERSIONS,
+)
+from ambient_package_update.metadata.maintainer import PackageMaintainer
+from ambient_package_update.metadata.package import PackageMetadata
+from ambient_package_update.metadata.readme import ReadmeContent
+
+METADATA = PackageMetadata(
+    package_name="django-commons-playground",
+    github_package_group="django-commons",
+    authors=[
+        PackageAuthor(
+            name="Tim Schilling",
+            email="schillingt@better-simple.com",
+        ),
+    ],
+    maintainer=PackageMaintainer(
+        name="Tim Schilling",
+        email="schillingt@better-simple.com",
+        url="https://www.better-simple.com",
+    ),
+    company="better-simple.com",
+    license=LICENSE_MIT,
+    license_year=2024,
+    development_status="5 - Production/Stable",
+    has_migrations=False,
+    readme_content=ReadmeContent(uses_internationalisation=False),
+    main_branch="main",
+    dependencies=[
+        f"Django>={SUPPORTED_DJANGO_VERSIONS[0]}",
+    ],
+    supported_django_versions=SUPPORTED_DJANGO_VERSIONS,
+    supported_python_versions=SUPPORTED_PYTHON_VERSIONS,
+    optional_dependencies={
+        "dev": [
+            *DEV_DEPENDENCIES,
+        ],
+    },
+    ruff_ignore_list=[],
+)

--- a/.ambient-package-update/templates/snippets/tagline.tpl
+++ b/.ambient-package-update/templates/snippets/tagline.tpl
@@ -1,0 +1,1 @@
+This is an example repository for Django Commons.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,rst,ini}]
+indent_style = space
+indent_size = 4
+ij_continuation_indent_size = 8
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+jobs:
+  linting:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install required packages
+        run: pip install pre-commit
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files --hook-stage push
+
+
+  tests:
+    name: Python ${{ matrix.python-version }}, django ${{ matrix.django-version }}
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', ]
+        django-version: ['42', '50', '51', ]
+
+        exclude:
+          - python-version: '3.9'
+            django-version: 50
+          - python-version: '3.9'
+            django-version: 51
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: pip install tox
+      - name: Run Tests
+        env:
+          TOXENV: django${{ matrix.django-version }}
+        run: tox
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ matrix.python-version }}-${{ matrix.django-version }}
+          path: '${{ github.workspace }}/.coverage.*'
+          include-hidden-files: true
+          if-no-files-found: error
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-24.04
+    needs: tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade coverage[toml]
+
+      - name: Download data
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ github.workspace }}
+          pattern: coverage-data-*
+          merge-multiple: true
+
+      - name: Combine coverage and fail if it's <100.0%
+        run: |
+          python -m coverage combine
+          python -m coverage html --skip-covered --skip-empty
+          python -m coverage report --fail-under=100.0
+          echo "## Coverage summary" >> $GITHUB_STEP_SUMMARY
+          python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,56 @@
+# you find the full pre-commit-tools docu under:
+# https://pre-commit.com/
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      # Run the Ruff linter.
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      # Run the Ruff formatter.
+      - id: ruff-format
+
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: 1.19.0
+    hooks:
+      - id: blacken-docs
+        additional_dependencies:
+        - black==24.4.2
+        files: '(?:README\.md|docs\/.*\.(?:md|rst))'
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.18.0
+    hooks:
+      - id: pyupgrade
+        args: [ --py39-plus ]
+        stages: [ pre-push ]
+
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.22.1
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "4.2"]
+        stages: [ pre-push ]
+
+  - repo: https://github.com/adamchainz/djade-pre-commit
+    rev: 1.3.0
+    hooks:
+    -   id: djade
+        args: [--target-version, "4.2"]
+        exclude: |
+          (?x)^(
+            charts/.*
+            |.*\.py
+          )$
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args:
+          [
+            "--pattern",
+            '^^(?!(?:feature|hotfix|bugfix|refactor|maintenance)/[\w\d\-_#]+).*$',
+          ]
+        stages: [ pre-commit ]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,31 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 better-simple.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include LICENSE.md
+recursive-exclude * *.pyc
+recursive-include django-commons-playground *.py *.html *.js *.cfg *.mo *.po

--- a/README.md
+++ b/README.md
@@ -1,6 +1,137 @@
-# Django Commons example repository
+[![PyPI release](https://img.shields.io/pypi/v/django-commons-playground.svg)](https://pypi.org/project/django-commons-playground/)
+[![Downloads](https://static.pepy.tech/badge/django-commons-playground)](https://pepy.tech/project/django-commons-playground)
+[![Coverage](https://img.shields.io/badge/Coverage-100.0%25-success)](https://github.com/django-commons/django-commons-playground/actions?workflow=CI)
+[![Linting](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Coding Style](https://img.shields.io/badge/code%20style-Ruff-000000.svg)](https://github.com/astral-sh/ruff)
+[![Documentation Status](https://readthedocs.org/projects/django-commons-playground/badge/?version=latest)](https://django-commons-playground.readthedocs.io/en/latest/?badge=latest)
 
-This is an example repository for Django Commons. Some relevant areas to review are:
+This is an example repository for Django Commons.
 
-- GitHub action ([release.yml](https://github.com/django-commons/django-commons-playground/blob/main/.github/workflows/release.yml)) for releasing to PyPI
-- [Documentation](docs/README.md)
+* [PyPI](https://pypi.org/project/django-commons-playground/)
+* [GitHub](https://github.com/django-commons/django-commons-playground)
+* [Full documentation](https://django-commons-playground.readthedocs.io/en/latest/index.html)
+* Creator & Maintainer: [Tim Schilling](https://www.better-simple.com)
+
+
+None
+
+## Installation
+
+- Install the package via pip:
+
+  `pip install django-commons-playground`
+
+  or via pipenv:
+
+  `pipenv install django-commons-playground`
+
+- Add module to `INSTALLED_APPS` within the main django `settings.py`:
+
+    ````
+    INSTALLED_APPS = (
+        ...
+        'django_commons_playground',
+    )
+     ````
+
+
+
+## Contribute
+
+### Setup package for development
+
+- Create a Python virtualenv and activate it
+- Install "pip-tools" with `pip install -U pip-tools`
+- Compile the requirements with `pip-compile --extra dev, -o requirements.txt pyproject.toml --resolver=backtracking`
+- Sync the dependencies with your virtualenv with `pip-sync`
+
+### Add functionality
+
+- Create a new branch for your feature
+- Change the dependency in your requirements.txt to a local (editable) one that points to your local file system:
+  `-e /Users/workspace/django-commons-playground` or via pip  `pip install -e /Users/workspace/django-commons-playground`
+- Ensure the code passes the tests
+- Create a pull request
+
+### Run tests
+
+- Run tests
+  ````
+  pytest --ds settings tests
+  ````
+
+- Check coverage
+  ````
+  coverage run -m pytest --ds settings tests
+  coverage report -m
+  ````
+
+### Git hooks (via pre-commit)
+
+We use pre-push hooks to ensure that only linted code reaches our remote repository and pipelines aren't triggered in
+vain.
+
+To enable the configured pre-push hooks, you need to [install](https://pre-commit.com/) pre-commit and run once:
+
+    pre-commit install -t pre-push -t pre-commit --install-hooks
+
+This will permanently install the git hooks for both, frontend and backend, in your local
+[`.git/hooks`](./.git/hooks) folder.
+The hooks are configured in the [`.pre-commit-config.yaml`](templates/.pre-commit-config.yaml.tpl).
+
+You can check whether hooks work as intended using the [run](https://pre-commit.com/#pre-commit-run) command:
+
+    pre-commit run [hook-id] [options]
+
+Example: run single hook
+
+    pre-commit run ruff --all-files --hook-stage push
+
+Example: run all hooks of pre-push stage
+
+    pre-commit run --all-files --hook-stage push
+
+### Update documentation
+
+- To build the documentation, run: `sphinx-build docs/ docs/_build/html/`.
+- Open `docs/_build/html/index.html` to see the documentation.
+
+
+
+### Publish to ReadTheDocs.io
+
+- Fetch the latest changes in GitHub mirror and push them
+- Trigger new build at ReadTheDocs.io (follow instructions in admin panel at RTD) if the GitHub webhook is not yet set
+  up.
+
+### Publish to PyPi
+
+- Update documentation about new/changed functionality
+
+- Update the `Changelog`
+
+- Increment version in main `__init__.py`
+
+- Create pull request / merge to main
+
+- This project uses the flit package to publish to PyPI. Thus publishing should be as easy as running:
+  ```
+  flit publish
+  ```
+
+  To publish to TestPyPI use the following ensure that you have set up your .pypirc as
+  shown [here](https://flit.readthedocs.io/en/latest/upload.html#using-pypirc) and use the following command:
+
+  ```
+  flit publish --repository testpypi
+  ```
+
+### Maintenance
+
+Please note that this package supports the [ambient-package-update](https://pypi.org/project/ambient-package-update/).
+So you don't have to worry about the maintenance of this package. All important configuration and setup files are
+being rendered by this updater. It works similar to well-known updaters like `pyupgrade` or `django-upgrade`.
+
+To run an update, refer to the [documentation page](https://pypi.org/project/ambient-package-update/)
+of the "ambient-package-update".
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Reporting Security Issues
+
+The maintainers of this package take security bugs seriously. We appreciate your efforts to responsibly
+disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security
+Advisory ["Report a Vulnerability"](https://github.com/django-commons/django-commons-playground/security/advisories/new) 
+tab.
+
+The maintainers will send a response indicating the next steps in handling your report. After the initial reply to
+your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask
+for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining the module.
+
+## Source
+
+This file was inspired by: https://github.com/electron/electron/blob/main/SECURITY.md

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,82 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+import django
+from django.conf import settings
+
+sys.path.insert(0, os.path.abspath(".."))  # so that we can access the "django-commons-playground" package
+settings.configure(
+    INSTALLED_APPS=[
+        "django.contrib.admin",
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.sessions",
+        "django.contrib.messages",
+        "django.contrib.staticfiles",
+        "django_commons_playground",
+    ],
+    SECRET_KEY="ASDFjklö123456890",
+)
+django.setup()
+
+from django_commons_playground import __version__  # noqa: E402
+
+# -- Project information -----------------------------------------------------
+
+project = "django-commons-playground"
+copyright = "2024, Ambient Innovation: GmbH"  # noqa: A001
+author = "Tim Schilling <schillingt@better-simple.com>"
+version = __version__
+release = __version__
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named "sphinx.ext.*") or your custom
+# ones.
+extensions = [
+    "sphinx_rtd_theme",
+    "sphinx.ext.autodoc",
+    "m2r2",
+]
+
+source_suffix = [".rst", ".md"]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "display_version": False,
+    "style_external_links": False,
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+# Set master doc file
+master_doc = "index"

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,233 @@
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["flit_core>=3.4"]
+build-backend = "flit_core.buildapi"
 
 [project]
-name = "django_commons_playground"
-version = "1.1.0"
+name = "django-commons-playground"
 authors = [
-  { name="Tim Schilling", email="schillingt@better-simple.com" },
+    {'name' = 'Tim Schilling', 'email' = 'schillingt@better-simple.com'},
 ]
-description = "A place to test things out"
 readme = "README.md"
-requires-python = ">=3.11"
 classifiers = [
-    "Programming Language :: Python :: 3",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Web Environment",
+    "Framework :: Django",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Utilities",
 ]
-keywords = [
-    "django",
-    "django commons",
+dynamic = ["version", "description"]
+license = {"file" = "LICENSE.md"}
+dependencies = [
+    'Django>=4.2',
 ]
 
+
+[project.optional-dependencies]
+dev = [
+   'typer~=0.12',
+   'freezegun~=1.5',
+   'pytest-django~=4.9',
+   'pytest-mock~=3.14',
+   'coverage~=7.6',
+   'pre-commit~=4.0',
+   'ruff~=0.6',
+   'sphinx~=7.1',
+   'sphinx-rtd-theme~=2.0',
+   'm2r2==0.3.3.post2',
+   'mistune<2.0.0',
+   'flit~=3.9',
+   'keyring~=25.4',
+   'ambient-package-update',
+]
+
+[tool.flit.module]
+name = "django_commons_playground"
+
 [project.urls]
-Homepage = "https://github.com/django-commons/django-commons-playground"
-Issues = "https://github.com/django-commons/django-commons-playground/issues"
+'Homepage' = 'https://github.com/django-commons/django-commons-playground/'
+'Documentation' = 'https://django-commons-playground.readthedocs.io/en/latest/index.html'
+'Maintained by' = 'https://www.better-simple.com'
+'Bugtracker' = 'https://github.com/django-commons/django-commons-playground/issues'
+'Changelog' = 'https://django-commons-playground.readthedocs.io/en/latest/features/changelog.html'
+
+[tool.ruff]
+lint.select = [
+    "E",       # pycodestyle errors
+    "W",       # pycodestyle warnings
+    "F",       # Pyflakes
+    "N",       # pep8-naming
+    "I",       # isort
+    "B",       # flake8-bugbear
+    "A",       # flake8-builtins
+    "DTZ",     # flake8-datetimez
+    "DJ",      # flake8-django
+    "TD",      # flake8-to-do
+    "RUF",     # Ruff-specific rules
+    "YTT",     # Avoid non-future-prove usages of "sys"
+    "C4",      # Checks for unnecessary conversions
+    "PIE",     # Bunch of useful rules
+    "INT",     # Validates your gettext translation strings
+    "PERF",    # PerfLint
+    "PGH",     # No all-purpose "# noqa" and eval validation
+    "PL",      # PyLint
+    "LOG",     # flake8-logging
+    "TID",     # flake8-tidy-imports
+    "PLR2004", # Magic numbers
+    "BLE",     # Checks for except clauses that catch all exceptions
+    "ANN401",  # Checks that function arguments are annotated with a more specific type than Any
+    "TRY",     # Clean try/except
+    "ERA",     # Commented out code
+]
+lint.ignore = [
+]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+lint.fixable = [
+    "E",       # pycodestyle errors
+    "W",       # pycodestyle warnings
+    "F",       # Pyflakes
+    "N",       # pep8-naming
+    "I",       # isort
+    "B",       # flake8-bugbear
+    "A",       # flake8-builtins
+    "DTZ",     # flake8-datetimez
+    "DJ",      # flake8-django
+    "TD",      # flake8-to-do
+    "RUF",     # Ruff-specific rules
+    "YTT",     # Avoid non-future-prove usages of "sys"
+    "C4",      # Checks for unnecessary conversions
+    "PIE",     # Bunch of useful rules
+    "INT",     # Validates your gettext translation strings
+    "PERF",    # PerfLint
+    "PGH",     # No all-purpose "# noqa" and eval validation
+    "PL",      # PyLint
+    "LOG",     # flake8-logging
+    "TID",     # flake8-tidy-imports
+    "PLR2004", # Magic numbers
+    "BLE",     # Checks for except clauses that catch all exceptions
+    "ANN401",  # Checks that function arguments are annotated with a more specific type than Any
+    "TRY",     # Clean try/except
+    "ERA",     # Commented out code
+]
+lint.unfixable = []
+
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "*/migrations/*"
+]
+
+# Same as Black.
+line-length = 120
+
+# Allow unused variables when underscore-prefixed.
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Assume Python 3.12
+target-version = "py312"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[tool.tox]
+legacy_tox_ini = """
+[testenv]
+# Django deprecation overview: https://www.djangoproject.com/download/
+deps =
+    django42: Django==4.2.*
+    django50: Django==5.0.*
+    django51: Django==5.1.*
+extras = dev,
+commands =
+    coverage run -m pytest --ds settings tests
+
+[gh-actions]
+python =
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313
+"""
+
+[tool.pytest.ini_options]
+python_files = [
+    "tests.py",
+    "test_*.py",
+    "*_tests.py",
+]
+
+[tool.coverage.run]
+branch = true
+parallel = true
+source = [
+    "django-commons-playground",
+    "tests",
+]
+omit = [
+  "setup.py",
+  "*_test.py",
+  "tests.py",
+  "testapp/*",
+  "tests/*",
+]
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+# Regexes for lines to exclude from consideration
+exclude_also = [
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+    # Don't check type hinting imports
+    "if typing.TYPE_CHECKING:",
+    "if TYPE_CHECKING:",
+]
+
+[tool.coverage.path]
+source = [
+    "django-commons-playground",
+    ".tox/**/site-packages",
+]

--- a/scripts/unix/install_requirements.sh
+++ b/scripts/unix/install_requirements.sh
@@ -1,0 +1,3 @@
+pip install -U pip-tools
+pip-compile --extra dev, -o requirements.txt pyproject.toml --resolver=backtracking
+pip-sync

--- a/scripts/unix/publish_to_pypi.sh
+++ b/scripts/unix/publish_to_pypi.sh
@@ -1,0 +1,2 @@
+ flit publish --repository testpypi
+ flit publish

--- a/scripts/windows/install_requirements.ps1
+++ b/scripts/windows/install_requirements.ps1
@@ -1,0 +1,3 @@
+pip install -U pip-tools
+pip-compile --extra dev, -o requirements.txt pyproject.toml --resolver=backtracking
+pip-sync

--- a/scripts/windows/publish_to_pypi.ps1
+++ b/scripts/windows/publish_to_pypi.ps1
@@ -1,0 +1,2 @@
+ flit publish --repository testpypi
+ flit publish


### PR DESCRIPTION
Hi @tim-schilling 

here's a very quick-and-dirty example of my https://pypi.org/project/ambient-package-update/ integrated with the playground.

What I've done:

* I've created a metadata file and configured it
* I ran the CLI script to update the project

I didn't put too much effort into the details since it's supposed to be a PoC. What do you think about it?

The updater has already some feature flags (migrations, internationalisation) but I'd be open to adding more if this would be a blocker.

Best from Cologne  
Ronny