### PR TITLE
Improve dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     groups:
       github-actions:
         patterns:
-          - "*"  # Group all Actions updates into a single larger pull request
+          - "*"  # Group all Actions updates into a single pull request
     schedule:
       interval: weekly
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,9 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly


### PR DESCRIPTION
Sync the existing dependabot config with the one that "membership" repo uses: https://github.com/django-commons/membership/blame/78870d861b9c9cb416f04213e3332c70b4594c14/.github/dependabot.yml

My original intention was to enable grouping, but having the same config for both repos felt better.