### PR TITLE
Use double-quotes for GITHUB_REF_NAME shell variable.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: >-
         gh release create
-        '${{ github.ref_name }}'
+        "${GITHUB_REF_NAME}"
         --repo '${{ github.repository }}'
         --notes ""
     - name: Upload artifact signatures to GitHub Release
@@ -98,5 +98,5 @@ jobs:
       # sigstore-produced signatures and certificates.
       run: >-
         gh release upload
-        '${{ github.ref_name }}' dist/**
+        "${GITHUB_REF_NAME}" dist/**
         --repo '${{ github.repository }}'


### PR DESCRIPTION
This properly expands it.