### PR TITLE
Add condition to skip release and test release workflows from forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
 
   build:
     name: Build distribution 📦
+    if: github.repository == 'django-commons/best-practices'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
 
   build:
     name: Build distribution 📦
+    # Prevent this workflow from running on forks
     if: github.repository == 'django-commons/best-practices'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -27,6 +27,7 @@ jobs:
     # Tag name:
     #   <version>.dev<yyyymmdd><iteration>
     name: Create dev version string
+    # Prevent this workflow from running on forks
     if: github.repository == 'django-commons/best-practices'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -27,6 +27,7 @@ jobs:
     # Tag name:
     #   <version>.dev<yyyymmdd><iteration>
     name: Create dev version string
+    if: github.repository == 'django-commons/best-practices'
     runs-on: ubuntu-latest
     outputs:
       dev_version: ${{ steps.output-dev-version.outputs.dev_version }}


### PR DESCRIPTION
After doing a release, when I synced my fork from the command line and pushed the new tag, the release workflow ran (and failed). There is no point running the release or test release workflows from forks. 

This PR is adding a condition to skip the initial job of each workfow. Following jobs will be skipped automatically due to dependencies.